### PR TITLE
Support dehumidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
 # Winix Controller
 
-This is a Python library for controlling Winix C545 Air Purifier
-devices. I reverse-engineered the API calls from the Android app. There
-are a few weird idiosyncrasies with the Winix backends.
+This is a Python library for controlling Winix devices I reverse-engineered the
+API calls from the Android app. There are a few weird idiosyncrasies with the
+Winix backends.
 
 Included in this package is a CLI program `winixctl`.
+
+## Supported Devices
+
+In addition to the confirmed models listed below, basic functions are expected
+to work on other devices as well. If the program does not support your device
+properly, please let us know.
+
+### Air Purifier
+
+- `C545`
+
+### Dehumidifier
+
+- `DXW*21*-***`
+
+### Air Conditioner
+
+TBD
 
 ## Setup
 
@@ -18,7 +36,7 @@ as the `winixctl` command for shell (which uses the library).
 $ winixctl
 usage: winixctl [-h] [--device DEVICE_SELECTOR] {login,refresh,devices,getstate,fan,power,mode,plasmawave} ...
 
-Winix C545 Air Purifier Control
+Winix Device Control
 
 positional arguments:
   {login,refresh,devices,getstate,fan,power,mode,plasmawave}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.3.0",
     author="Hunter Fernandes",
     author_email="hunter@hfernandes.com",
-    description="Programmatically control the Winix C545",
+    description="Programmatically control the Winix",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/hfern/winix",

--- a/winix/__init__.py
+++ b/winix/__init__.py
@@ -1,2 +1,7 @@
 from winix.auth import login
-from winix.driver import WinixAccount, WinixDevice, WinixDeviceStub
+from winix.driver import (
+    WinixAccount,
+    WinixDevice,
+    AirPurifierDevice,
+    WinixDeviceStub
+)

--- a/winix/__init__.py
+++ b/winix/__init__.py
@@ -3,5 +3,7 @@ from winix.driver import (
     WinixAccount,
     WinixDevice,
     AirPurifierDevice,
+    DehumidifierDevice,
+    AirConditionerDevice,
     WinixDeviceStub
 )

--- a/winix/cmd.py
+++ b/winix/cmd.py
@@ -323,7 +323,7 @@ def main():
 
     cls = commands[cmd]
     try:
-        cls(args, config=Configuration("~/.config/winix/config.json")).execute()
+        cls(args, config=Configuration(DEFAULT_CONFIG_PATH)).execute()
     except UserError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)

--- a/winix/cmd.py
+++ b/winix/cmd.py
@@ -366,7 +366,12 @@ class StateCmd(Cmd):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Winix C545 Air Purifier Control")
+    parser = argparse.ArgumentParser(
+        description="Winix Device Control\n"
+                    "[AIR]: Air Purifier\n"
+                    "[DEH]: Dehumidifier\n",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
     parser.add_argument(
         "--device",
         "-D",

--- a/winix/cmd.py
+++ b/winix/cmd.py
@@ -11,6 +11,8 @@ from winix import (
     WinixAccount,
     WinixDevice,
     AirPurifierDevice,
+    DehumidifierDevice,
+    AirConditionerDevice,
     WinixDeviceStub
 )
 from winix.auth import WinixAuthResponse, login, refresh
@@ -93,7 +95,13 @@ class Cmd:
         device_id = device_config.id
         device_type = device_config.product_group
 
-        return AirPurifierDevice(device_id)
+        if "Air" in device_type:
+            return AirPurifierDevice(device_id)
+        elif "Deh" in device_type:
+            return DehumidifierDevice(device_id)
+
+        # TODO: check device_type name
+        return AirConditionerDevice(device_id)
 
 
 class LoginCmd(Cmd):
@@ -189,7 +197,7 @@ class DevicesCmd(Cmd):
 class FanCmd(Cmd):
     parser_args = {
         "name": "fan",
-        "help": "Fan speed (airflow) controls",
+        "help": "Fan speed (airflow) controls [AIR, DEH]",
     }
 
     @classmethod
@@ -209,7 +217,7 @@ class FanCmd(Cmd):
 class PowerCmd(Cmd):
     parser_args = {
         "name": "power",
-        "help": "Power controls",
+        "help": "Power controls [AIR, DEH]",
     }
 
     @classmethod
@@ -224,12 +232,23 @@ class PowerCmd(Cmd):
 class ModeCmd(Cmd):
     parser_args = {
         "name": "mode",
-        "help": "Mode controls",
+        "help": "Mode controls [AIR, DEH]",
     }
 
     @classmethod
     def add_parser(cls, parser):
-        parser.add_argument("state", help="Mode state", choices=["auto", "manual"])
+        parser.add_argument(
+            "state",
+            help="Mode state",
+            choices=[
+                "auto",
+                "manual",
+                "clothes",
+                "shoes",
+                "quiet",
+                "continuous"
+            ]
+        )
 
     def execute(self):
         self.get_device_cls().control(self.parser_args["name"], self.args.state)
@@ -239,7 +258,7 @@ class ModeCmd(Cmd):
 class PlasmawaveCmd(Cmd):
     parser_args = {
         "name": "plasmawave",
-        "help": "Plasmawave controls",
+        "help": "Plasmawave controls [AIR]",
     }
 
     @classmethod
@@ -248,6 +267,68 @@ class PlasmawaveCmd(Cmd):
 
     def execute(self):
         self.get_device_cls().control("plasma", self.args.state)
+        print("ok")
+
+
+class HumidityCmd(Cmd):
+    parser_args = {
+        "name": "humidity",
+        "help": "Target humidity controls [DEH]",
+    }
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser.add_argument("percent", help="Target humidity in range 35~70%%",
+                            type=int)
+
+    def execute(self):
+        self.get_device_cls().control(self.parser_args["name"], str(self.args.percent))
+        print("ok")
+
+
+class ChildLockCmd(Cmd):
+    parser_args = {
+        "name": "child-lock",
+        "help": "Child lock controls [DEH]",
+    }
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser.add_argument("state", help="Child lock state", choices=["on", "off"])
+
+    def execute(self):
+        self.get_device_cls().control("child_lock", self.args.state)
+        print("ok")
+
+
+class UVSanitizeCmd(Cmd):
+    parser_args = {
+        "name": "uv-sanitize",
+        "help": "UV sanitize controls [DEH]",
+    }
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser.add_argument("state", help="UV sanitize state", choices=["on", "off"])
+
+    def execute(self):
+        self.get_device_cls().control("uv_sanitize", self.args.state)
+        print("ok")
+
+
+class TimerCmd(Cmd):
+    parser_args = {
+        "name": "timer",
+        "help": "timer controls [DEH]",
+    }
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser.add_argument("hour", help="Set timer in range 1~12 hour",
+                            type=int)
+
+    def execute(self):
+        self.get_device_cls().control(self.parser_args["name"], str(self.args.hour))
         print("ok")
 
 
@@ -281,7 +362,7 @@ class StateCmd(Cmd):
     def execute(self):
         status = self.get_device_cls().get_state()
         for f, v in status.items():
-            print(f"{f:>15} : {v}")
+            print(f"{f:>16} : {v}")
 
 
 def main():
@@ -306,6 +387,10 @@ def main():
             PowerCmd,
             ModeCmd,
             PlasmawaveCmd,
+            HumidityCmd,
+            ChildLockCmd,
+            UVSanitizeCmd,
+            TimerCmd,
         )
     }
 

--- a/winix/cmd.py
+++ b/winix/cmd.py
@@ -7,7 +7,12 @@ from getpass import getpass
 from os import path, makedirs
 from typing import Optional, List
 
-from winix import WinixAccount, WinixDevice, WinixDeviceStub
+from winix import (
+    WinixAccount,
+    WinixDevice,
+    AirPurifierDevice,
+    WinixDeviceStub
+)
 from winix.auth import WinixAuthResponse, login, refresh
 
 DEFAULT_CONFIG_PATH = "~/.config/winix/config.json"
@@ -83,8 +88,12 @@ class Cmd:
         self.args = args
         self.config = config
 
-    def active_device_id(self) -> str:
-        return self.config.device(self.args.device_selector).id
+    def get_device_cls(self):
+        device_config = self.config.device(self.args.device_selector)
+        device_id = device_config.id
+        device_type = device_config.product_group
+
+        return AirPurifierDevice(device_id)
 
 
 class LoginCmd(Cmd):
@@ -180,7 +189,7 @@ class DevicesCmd(Cmd):
 class FanCmd(Cmd):
     parser_args = {
         "name": "fan",
-        "help": "Fan speed controls",
+        "help": "Fan speed (airflow) controls",
     }
 
     @classmethod
@@ -192,10 +201,8 @@ class FanCmd(Cmd):
         )
 
     def execute(self):
-        level = self.args.level
         # TODO(Hunter): Support getting the fan state instead of only being able to set it
-        device = WinixDevice(self.active_device_id())
-        getattr(device, level)()
+        self.get_device_cls().control("airflow", self.args.level)
         print("ok")
 
 
@@ -210,9 +217,7 @@ class PowerCmd(Cmd):
         parser.add_argument("state", help="Power state", choices=["on", "off"])
 
     def execute(self):
-        state = self.args.state
-        device = WinixDevice(self.active_device_id())
-        getattr(device, state)()
+        self.get_device_cls().control(self.parser_args["name"], self.args.state)
         print("ok")
 
 
@@ -227,9 +232,7 @@ class ModeCmd(Cmd):
         parser.add_argument("state", help="Mode state", choices=["auto", "manual"])
 
     def execute(self):
-        state = self.args.state
-        device = WinixDevice(self.active_device_id())
-        getattr(device, state)()
+        self.get_device_cls().control(self.parser_args["name"], self.args.state)
         print("ok")
 
 
@@ -244,9 +247,7 @@ class PlasmawaveCmd(Cmd):
         parser.add_argument("state", help="Plasmawave state", choices=["on", "off"])
 
     def execute(self):
-        state = "plasmawave_on" if self.args.state == "on" else "plasmawave_off"
-        device = WinixDevice(self.active_device_id())
-        getattr(device, state)()
+        self.get_device_cls().control("plasma", self.args.state)
         print("ok")
 
 
@@ -278,9 +279,7 @@ class StateCmd(Cmd):
         pass
 
     def execute(self):
-        device = WinixDevice(self.active_device_id())
-        state = "get_state"
-        status = getattr(device, state)()
+        status = self.get_device_cls().get_state()
         for f, v in status.items():
             print(f"{f:>15} : {v}")
 

--- a/winix/cmd.py
+++ b/winix/cmd.py
@@ -289,7 +289,7 @@ class HumidityCmd(Cmd):
 class ChildLockCmd(Cmd):
     parser_args = {
         "name": "child-lock",
-        "help": "Child lock controls [DEH]",
+        "help": "Child lock controls [AIR, DEH]",
     }
 
     @classmethod
@@ -365,6 +365,22 @@ class StateCmd(Cmd):
             print(f"{f:>16} : {v}")
 
 
+class BrightnessLevelCmd(Cmd):
+    parser_args = {
+        "name": "brightness",
+        "help": "Brightness level controls [AIR]",
+    }
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser.add_argument("level", help="Brigness level",
+                            type=int)
+
+    def execute(self):
+        self.get_device_cls().control("brightness_level", str(self.args.level))
+        print("ok")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Winix Device Control\n"
@@ -396,6 +412,7 @@ def main():
             ChildLockCmd,
             UVSanitizeCmd,
             TimerCmd,
+            BrightnessLevelCmd,
         )
     }
 

--- a/winix/driver.py
+++ b/winix/driver.py
@@ -169,3 +169,45 @@ class AirPurifierDevice(WinixDevice):
         "plasma": {"off": "0", "on": "1"},
         "air_quality": {"good": "01", "fair": "02", "poor": "03"},
     }
+
+
+class DehumidifierDevice(WinixDevice):
+    category_keys = {
+        "power": "D02",
+        "mode": "D03",
+        "airflow": "D04",
+        "target_humidity": "D05",
+        "child_lock": "D08",
+        "current_humidity": "D10",
+        "water_bucket": "D11",
+        "uv_sanitize": "D13",
+        "timer": "D15",
+    }
+
+    state_keys = {
+        "power": {
+            "off": "0",
+            "on": "1",
+            "off-dry": "2"
+        },
+        "mode": {
+            "auto": "01",
+            "manual": "02",
+            "clothes": "03",
+            "shoes": "04",
+            "quiet": "05",
+            "continuous": "06"
+        },
+        "airflow": {
+            "high": "01",
+            "low": "02",
+            "turbo": "03",
+        },
+        "child_lock": {"disabled": "0", "enabled": "1"},
+        "water_bucket": {"not full": "0", "full or detached": "1"},
+        "uv_sanitize": {"disabled": "0", "enabled": "1"},
+    }
+
+
+class AirConditionerDevice(WinixDevice):
+    pass # TBD

--- a/winix/driver.py
+++ b/winix/driver.py
@@ -150,6 +150,8 @@ class AirPurifierDevice(WinixDevice):
         "airflow": "A04",
         "aqi": "A05",
         "plasma": "A07",
+        "child_lock": "A08",
+        "brightness_level": "A16",
         "filter_hour": "A21",
         "air_quality": "S07",
         "air_qvalue": "S08",
@@ -166,6 +168,7 @@ class AirPurifierDevice(WinixDevice):
             "turbo": "05",
             "sleep": "06",
         },
+        "child_lock": {"off": "0", "on": "1"},
         "plasma": {"off": "0", "on": "1"},
         "air_quality": {"good": "01", "fair": "02", "poor": "03"},
     }

--- a/winix/driver.py
+++ b/winix/driver.py
@@ -12,6 +12,7 @@ class WinixDeviceStub:
     alias: str
     location_code: str
     filter_replace_date: str
+    product_group: str
 
 
 class WinixAccount:
@@ -61,6 +62,7 @@ class WinixAccount:
                 alias=d["deviceAlias"],
                 location_code=d["deviceLocCode"],
                 filter_replace_date=d["filterReplaceDate"],
+                product_group=d["productGroup"],
             )
             for d in resp.json()["deviceInfoList"]
         ]
@@ -109,7 +111,39 @@ class WinixAccount:
 class WinixDevice:
     CTRL_URL = "https://us.api.winix-iot.com/common/control/devices/{deviceid}/A211/{attribute}:{value}"
     STATE_URL = "https://us.api.winix-iot.com/common/event/sttus/devices/{deviceid}"
+    category_keys = None
+    state_keys = None
 
+    def __init__(self, id):
+        self.id = id
+
+    def control(self, category: str, state: str):
+        url = self.CTRL_URL.format(
+            deviceid=self.id,
+            attribute=self.category_keys[category],
+            value=self.state_keys[category][state]
+        )
+        requests.get(url)
+
+    def get_state(self):
+        r = requests.get(self.STATE_URL.format(deviceid=self.id))
+        payload = r.json()["body"]["data"][0]["attributes"]
+
+        output = dict()
+        for (payload_key, attribute) in payload.items():
+            for (category, local_key) in self.category_keys.items():
+                if payload_key == local_key:
+                    if category in self.state_keys.keys():
+                        for (value_key, value) in self.state_keys[category].items():
+                            if attribute == value:
+                                output[category] = value_key
+                    else:
+                        output[category] = int(attribute)
+
+        return output
+
+
+class AirPurifierDevice(WinixDevice):
     category_keys = {
         "power": "A02",
         "mode": "A03",
@@ -135,69 +169,3 @@ class WinixDevice:
         "plasma": {"off": "0", "on": "1"},
         "air_quality": {"good": "01", "fair": "02", "poor": "03"},
     }
-
-    def __init__(self, id):
-        self.id = id
-
-    def off(self):
-        self._rpc_attr(self.category_keys["power"], self.state_keys["power"]["off"])
-
-    def on(self):
-        self._rpc_attr(self.category_keys["power"], self.state_keys["power"]["on"])
-
-    def auto(self):
-        self._rpc_attr(self.category_keys["mode"], self.state_keys["mode"]["auto"])
-
-    def manual(self):
-        self._rpc_attr(self.category_keys["mode"], self.state_keys["mode"]["manual"])
-
-    def plasmawave_off(self):
-        self._rpc_attr(self.category_keys["plasma"], self.state_keys["plasma"]["off"])
-
-    def plasmawave_on(self):
-        self._rpc_attr(self.category_keys["plasma"], self.state_keys["plasma"]["on"])
-
-    def low(self):
-        self._rpc_attr(self.category_keys["airflow"], self.state_keys["airflow"]["low"])
-
-    def medium(self):
-        self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["medium"]
-        )
-
-    def high(self):
-        self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["high"]
-        )
-
-    def turbo(self):
-        self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["turbo"]
-        )
-
-    def sleep(self):
-        self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["sleep"]
-        )
-
-    def _rpc_attr(self, attr: str, value: str):
-        requests.get(
-            self.CTRL_URL.format(deviceid=self.id, attribute=attr, value=value)
-        )
-
-    def get_state(self):
-        r = requests.get(self.STATE_URL.format(deviceid=self.id))
-        payload = r.json()["body"]["data"][0]["attributes"]
-
-        output = dict()
-        for (payload_key, attribute) in payload.items():
-            for (category, local_key) in self.category_keys.items():
-                if payload_key == local_key:
-                    if category in self.state_keys.keys():
-                        for (value_key, value) in self.state_keys[category].items():
-                            if attribute == value:
-                                output[category] = value_key
-                    else:
-                        output[category] = int(attribute)
-
-        return output


### PR DESCRIPTION
Hello,

I recently purchased a Winix dehumidifier and came across your repository.

Thanks to **winixctl**, I was able to easily analyze the command codes for my device.

I truly appreciate your pioneering efforts in reverse engineering this.

Since the repository hasn't been updated for quite some time, I'm not sure if you're still  maintaining it. If you don't have the time to review this, feel free to close the PR.

The main change in this PR is that it automatically selects the appropriate device class based on the product group information obtained during login.

There are a few caveats to note:

* Existing `config.json` files may not contain the product group information, which can lead to errors. You may need to delete the file and log-in again.
* The subcommands for both **airpurifier** and **dehumidifier** are displayed together, which can be somewhat extensive.
* options in subcommand are not marked as supported or unsupported per device.

winixctl log

```
usage: winixctl [-h] [--device DEVICE_SELECTOR] {login,refresh,devices,getstate,fan,power,mode,plasmawave,humidity,child-lock,uv-sanitize,timer,brightness} ...

Winix Device Control
[AIR]: Air Purifier
[DEH]: Dehumidifier

positional arguments:
  {login,refresh,devices,getstate,fan,power,mode,plasmawave,humidity,child-lock,uv-sanitize,timer,brightness}
    login               Authenticate Winix account
    refresh             Refresh account device metadata
    devices             List registered Winix devices
    getstate            Get device state
    fan                 Fan speed (airflow) controls [AIR, DEH]
    power               Power controls [AIR, DEH]
    mode                Mode controls [AIR, DEH]
    plasmawave          Plasmawave controls [AIR]
    humidity            Target humidity controls [DEH]
    child-lock          Child lock controls [AIR, DEH]
    uv-sanitize         UV sanitize controls [DEH]
    timer               timer controls [DEH]
    brightness          Brightness level controls [AIR]

options:
  -h, --help            show this help message and exit
  --device DEVICE_SELECTOR, -D DEVICE_SELECTOR
                        Device Index/Mac/Alias to use
```